### PR TITLE
QtMaterialCheckBox does not emit a click signal when clicked like QCheckBox does, fix that

### DIFF
--- a/components/materiallib/qtmaterialcheckable.cpp
+++ b/components/materiallib/qtmaterialcheckable.cpp
@@ -402,6 +402,7 @@ void QtMaterialCheckable::mousePressEvent(QMouseEvent *event)
     d->rippleOverlay->addRipple(ripple);
 
     setChecked(!isChecked());
+    emit clicked(isChecked());
 }
 
 /*!


### PR DESCRIPTION
QtMaterialCheckBox does not emit a click signal when clicked like QCheckBox does, fix that